### PR TITLE
Scroll to top on page change

### DIFF
--- a/src/components/ScrollToTop/index.js
+++ b/src/components/ScrollToTop/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { withRouter } from 'react-router-dom'
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0)
+    }
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+export default withRouter(ScrollToTop)

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { HashRouter } from 'react-router-dom'
 import Main from './components/Main'
 import App from './components/App'
 import Page from './components/Page'
+import ScrollToTop from './components/ScrollToTop'
 import './index.css'
 // Fela Setup
 // http://fela.js.org/docs/guides/UsageWithReact.html
@@ -20,7 +21,9 @@ ReactDOM.render(
     <Provider renderer={renderer} mountNode={mountNode}>
       <Main>
         <Page>
-          <App />
+          <ScrollToTop>
+            <App />
+          </ScrollToTop>
         </Page>
       </Main>
     </Provider>


### PR DESCRIPTION
Previously scroll position remained when navigating to different pages, but now when we open a new pages it is always on the top. 