### PR TITLE
fix width of code examples so they adjust based on viewport

### DIFF
--- a/src/components/Code/styles.css
+++ b/src/components/Code/styles.css
@@ -2,7 +2,7 @@
   background-color: #EFEFEF;
   padding: 1em 3em;
   margin: 1.5em 0;
-  width: 100vw;
+  width: calc(100% + 6em); 
   position: relative;
   left: -3em;
   overflow: auto;


### PR DESCRIPTION
I just finished the last tasks of the workshop (awesome that there were some more tasks btw!) and noticed that you cannot access the large code examples if you use a small viewport: they are hidden behind the menu.

So I adjusted the size of the code div, so you gain the horizontal scroll to look at the wanted code parts.

![after](https://user-images.githubusercontent.com/4151393/44927567-49654880-ad55-11e8-8e5e-169ddd034a56.gif)

(6em because its the 3em of the left side + 3em to the right side to have a symmetric view.)